### PR TITLE
How to fix Authorization failed?

### DIFF
--- a/README.org
+++ b/README.org
@@ -25,7 +25,7 @@ Minimally the user needs to specify a pair of languages in the customization var
 (setq txl-deepl-api-key "my-api-key")
 #+END_SRC
 
-Other configuration variables are ~txl-deelp-split-sentences~, ~txl-deepl-preserve-formatting~, and ~txl-deepl-formality~.  See inline documentation for details.
+Other configuration variables are ~txl-deepl-api-url~, ~txl-deelp-split-sentences~, ~txl-deepl-preserve-formatting~, and ~txl-deepl-formality~.  See inline documentation for details.
 
 For convenience the translation command can be bound to a keyboard shortcut.  Example:
 

--- a/txl.el
+++ b/txl.el
@@ -55,12 +55,17 @@
 
 Will be restored when the buffer for reviewing the translation is closed.")
 
-(defvar txl-deepl-api-url "https://api.deepl.com/v2/translate"
-  "URL of the translation API.")
-
 (defgroup txl nil
   "Use online machine translation services."
   :group 'text)
+
+(defcustom txl-deepl-api-url "https://api-free.deepl.com/v2/translate"
+  "URL of the translation API. e.g. https://api-free.deepl.com/v2/translate or https://api.deepl.com/v2/translate"
+  :type 'string)
+
+(defcustom txl-deepl-api-key ""
+  "The authentication key used to access the translation API."
+  :type 'string)
 
 (defcustom txl-languages '(DE . EN-US)
   "The two languages between which DeepL will translate."


### PR DESCRIPTION
With region marked e.g. "Guten Tag"

`C-x t` `txl-translate-region-or-paragraph`

*Authorization failed.  Please supply a valid auth<sub>key</sub> parameter*

    (add-to-list 'load-path "~/src/txl.el")
    (require 'txl)
    (setq txl-languages '(DE . EN-US))
    (setq txl-deepl-api-key "my_free_dev_deepl_api_key")
    (global-set-key (kbd "C-x t")   'txl-translate-region-or-paragraph)

.

    curl -H "Authorization: DeepL-Auth-Key my_free_dev_deepl_api_key" https://api-free.deepl.com/v2/usage

    {"character_count":0,"character_limit":500000}

Nice work, thank you
