### PR TITLE
Make txl-accept-translation always replace the translated text

### DIFF
--- a/txl.el
+++ b/txl.el
@@ -225,9 +225,10 @@ written, i.e. the target language of a translation."
 
 (defun txl-replace-region-or-paragraph (string)
   "Replace region or paragraph with STRING."
-  (let ((beginning (txl-beginning)))
+  (let ((beginning (txl-beginning))
+        (end (txl-end)))
     (goto-char (txl-beginning))
-    (delete-region beginning (txl-end))
+    (delete-region beginning end)
     (insert string)))
 
 ;;;###autoload


### PR DESCRIPTION
When selecting a region and calling `txl-translate-region-or-paragraph`, after accepting the translation, the original text remains in the buffer but according the documentation, it shouldn't. This commit fixes that.

I'm not sure what causes the described behavior. My initial guess was `transient-mark-mode`, but switching it off didn't help.